### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,6 @@
 name: Build & Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/p1va/symbols/security/code-scanning/12](https://github.com/p1va/symbols/security/code-scanning/12)

To fix this problem, we should add an explicit `permissions` block to the workflow to restrict the permissions that the jobs receive from the default `GITHUB_TOKEN`. The safest and most maintainable approach is to add a root-level permissions block, which will apply to all jobs by default (unless a job overrides it). Since the workflow is using `actions/checkout` and `actions/upload-artifact`, and not making any changes to repo contents, the appropriate permission is `contents: read`, as well as the default artifact upload permissions (which do not require extra write permissions). Add the block directly under the workflow `name:` (i.e., after line 1), and before the `on:` key. No other changes are required; this minimizes privilege for all jobs unless specific jobs require more (none appear to here).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
